### PR TITLE
Update metrics: Add if before metric rules (applicable, compliant)

### DIFF
--- a/metrics/DevelopmentLifeCycle/ApprovedCommitAuthorEnforced/metric.rego
+++ b/metrics/DevelopmentLifeCycle/ApprovedCommitAuthorEnforced/metric.rego
@@ -8,11 +8,11 @@ default applicable = false
 
 default compliant = false
 
-applicable {
+applicable if {
 	# we are only interested in code repositories
 	repo
 }
 
-compliant {
+compliant if {
 	compare(data.operator, data.target_value, repo.approvedCommitAuthorEnforced)
 }

--- a/metrics/DevelopmentLifeCycle/CodeSignoff/metric.rego
+++ b/metrics/DevelopmentLifeCycle/CodeSignoff/metric.rego
@@ -8,11 +8,11 @@ default applicable = false
 
 default compliant = false
 
-applicable {
+applicable if {
 	# we are only interested in code repositories
 	repo
 }
 
-compliant {
+compliant if {
 	compare(data.operator, data.target_value, repo.codeSignoff)
 }

--- a/metrics/DevelopmentLifeCycle/SignedCommits/metric.rego
+++ b/metrics/DevelopmentLifeCycle/SignedCommits/metric.rego
@@ -8,11 +8,11 @@ default applicable = false
 
 default compliant = false
 
-applicable {
+applicable if {
 	# we are only interested in code repositories
 	repo
 }
 
-compliant {
+compliant if {
 	compare(data.operator, data.target_value, repo.signedCommits)
 }

--- a/metrics/DevelopmentLifeCycle/SignedSignoff/metric.rego
+++ b/metrics/DevelopmentLifeCycle/SignedSignoff/metric.rego
@@ -8,11 +8,11 @@ default applicable = false
 
 default compliant = false
 
-applicable {
+applicable if {
 	# we are only interested in code repositories
 	repo
 }
 
-compliant {
+compliant if {
 	compare(data.operator, data.target_value, repo.signedSignoff)
 }

--- a/metrics/EndpointSecurity/AutomaticUpdatesEnabled/metric.rego
+++ b/metrics/EndpointSecurity/AutomaticUpdatesEnabled/metric.rego
@@ -7,10 +7,10 @@ default applicable = false
 
 default compliant = false
 
-applicable {
+applicable if {
 	au
 }
 
-compliant {
+compliant if {
 	compare(data.operator, data.target_value, au.enabled)
 }

--- a/metrics/EndpointSecurity/AutomaticUpdatesInterval/metric.rego
+++ b/metrics/EndpointSecurity/AutomaticUpdatesInterval/metric.rego
@@ -7,11 +7,11 @@ default applicable = false
 
 default compliant = false
 
-applicable {
+applicable if {
 	au
 }
 
-compliant {
+compliant if {
 	# Check if interval is > 0.
 	# The discovery should set the interval to 0 if the the automatic update is not enabled. If we do not check 'interval > 0' it can result in 'AutomaticUpdatesEnabled=false' and  'AutomaticUpdatesInterval=true'. 
 	compare(">", 0, time.parse_duration_ns(au.interval) / (1000000000 * 86400))

--- a/metrics/EndpointSecurity/MalwareProtectionEnabled/metric.rego
+++ b/metrics/EndpointSecurity/MalwareProtectionEnabled/metric.rego
@@ -7,10 +7,10 @@ default applicable = false
 
 default compliant = false
 
-applicable {
+applicable if {
 	mp
 }
 
-compliant {
+compliant if {
 	compare(data.operator, data.target_value, mp.enabled)
 }

--- a/metrics/EndpointSecurity/MalwareProtectionOutput/metric.rego
+++ b/metrics/EndpointSecurity/MalwareProtectionOutput/metric.rego
@@ -7,11 +7,11 @@ default applicable = false
 
 default compliant = false
 
-applicable {
+applicable if {
 	logging
 }
 
-compliant {
+compliant if {
 	# all logging services that the applicationLogging is storing the logs to should be listed in the field loggingServiceIds
 	compare(data.operator, data.target_value, count(logging.loggingServiceIds))
 }

--- a/metrics/IdentityManagement/AdminMFAEnabled/metric.rego
+++ b/metrics/IdentityManagement/AdminMFAEnabled/metric.rego
@@ -8,11 +8,11 @@ default applicable = false
 
 default compliant = false
 
-applicable {
+applicable if {
 	# we are only interested in some kind of privileged user    
 	identity.privileged
 }
 
-compliant {
+compliant if {
 	compare(data.operator, data.target_value, identity.enforceMFA)
 }

--- a/metrics/IdentityManagement/IdentityPasswordPolicyEnabled/metric.rego
+++ b/metrics/IdentityManagement/IdentityPasswordPolicyEnabled/metric.rego
@@ -8,12 +8,12 @@ default applicable = false
 
 default compliant = false
 
-applicable {
+applicable if {
 	# the resource type should be an Identity
 	resource.type[_] == "Identity"
 }
 
-compliant {
+compliant if {
 	# we are just assuming that the standard policy looks good
 	compare(data.operator, data.target_value, identity.disablePasswordPolicy)
 }

--- a/metrics/IdentityManagement/IdentityRecentActivity/metric.rego
+++ b/metrics/IdentityManagement/IdentityRecentActivity/metric.rego
@@ -8,12 +8,12 @@ default applicable = false
 
 default compliant = false
 
-applicable {
+applicable if {
         # we are only interested in active accounts, deactivated accounts are already inactive
 	identity.activated
 }
 
-compliant {
+compliant if {
 	ts := time.parse_rfc3339_ns(identity.lastActivity)
 	now := time.now_ns()
 

--- a/metrics/IdentityManagement/ObjectStoragePublicAccessDisabled/metric.rego
+++ b/metrics/IdentityManagement/ObjectStoragePublicAccessDisabled/metric.rego
@@ -7,11 +7,11 @@ default compliant = false
 
 default applicable = false
 
-applicable {
+applicable if {
 	# the resource type should be an ObjectStorage
 	storage.type[_] == "ObjectStorage"
 }
 
-compliant {
+compliant if {
 	compare(data.operator, data.target_value, storage.publicAccess)
 }

--- a/metrics/LoggingMonitoring/ActivityLoggingEnabled/metric.rego
+++ b/metrics/LoggingMonitoring/ActivityLoggingEnabled/metric.rego
@@ -9,10 +9,10 @@ default compliant = false
 
 enabled := input.resourceLogging.enabled
 
-applicable {
+applicable if {
 	enabled != null
 }
 
-compliant {
+compliant if {
 	compare(data.operator, data.target_value, enabled)
 }

--- a/metrics/LoggingMonitoring/AnomalyDetectionEnabled/metric.rego
+++ b/metrics/LoggingMonitoring/AnomalyDetectionEnabled/metric.rego
@@ -9,10 +9,10 @@ default compliant = false
 
 enabled := input.anomalyDetection.enabled
 
-applicable {
+applicable if {
 	enabled != null
 }
 
-compliant {
+compliant if {
 	compare(data.operator, data.target_value, enabled)
 }

--- a/metrics/LoggingMonitoring/AnomalyDetectionOutput/metric.rego
+++ b/metrics/LoggingMonitoring/AnomalyDetectionOutput/metric.rego
@@ -8,10 +8,10 @@ default applicable = false
 
 default compliant = false
 
-applicable {
+applicable if {
 	logging 
 }
 
-compliant {
+compliant if {
 	compare(data.operator, data.target_value, count(logging.loggingServiceIds))
 }

--- a/metrics/LoggingMonitoring/BootLoggingEnabled/metric.rego
+++ b/metrics/LoggingMonitoring/BootLoggingEnabled/metric.rego
@@ -8,10 +8,10 @@ default applicable = false
 
 default compliant = false
 
-applicable {
+applicable if {
 	logging
 }
 
-compliant {
+compliant if {
 	compare(data.operator, data.target_value, logging.enabled)
 }

--- a/metrics/LoggingMonitoring/BootLoggingOutput/metric.rego
+++ b/metrics/LoggingMonitoring/BootLoggingOutput/metric.rego
@@ -8,10 +8,10 @@ default applicable = false
 
 default compliant = false
 
-applicable {
+applicable if {
 	logging
 }
 
-compliant {
+compliant if {
 	compare(data.operator, data.target_value, count(logging.loggingServiceIds))
 }

--- a/metrics/LoggingMonitoring/BootLoggingRetention/metric.rego
+++ b/metrics/LoggingMonitoring/BootLoggingRetention/metric.rego
@@ -8,11 +8,11 @@ default applicable = false
 
 default compliant = false
 
-applicable {
+applicable if {
 	logging
 }
 
-compliant {
+compliant if {
 	# time.Duration is nanoseconds, we want to convert this to days
 	days := time.parse_duration_ns(logging.retentionPeriod) / (((1000 * 1000) * 1000) * 3600)
 

--- a/metrics/LoggingMonitoring/OSLoggingEnabled/metric.rego
+++ b/metrics/LoggingMonitoring/OSLoggingEnabled/metric.rego
@@ -8,10 +8,10 @@ default applicable = false
 
 default compliant = false
 
-applicable {
+applicable if {
 	logging
 }
 
-compliant {
+compliant if {
 	compare(data.operator, data.target_value, logging.enabled)
 }

--- a/metrics/LoggingMonitoring/OSLoggingOutput/metric.rego
+++ b/metrics/LoggingMonitoring/OSLoggingOutput/metric.rego
@@ -10,10 +10,10 @@ default compliant = false
 
 metricConfiguration := data.target_value
 
-applicable {
+applicable if {
 	logging
 }
 
-compliant {
+compliant if {
 	compare(data.operator, data.target_value, count(logging.loggingServiceIds))
 }

--- a/metrics/LoggingMonitoring/OSLoggingRetention/metric.rego
+++ b/metrics/LoggingMonitoring/OSLoggingRetention/metric.rego
@@ -8,11 +8,11 @@ default applicable = false
 
 default compliant = false
 
-applicable {
+applicable if {
 	logging
 }
 
-compliant {
+compliant if {
 	# time.Duration is nanoseconds, we want to convert this to days
 	days := time.parse_duration_ns(logging.retentionPeriod) / (((1000 * 1000) * 1000) * 3600)
 

--- a/metrics/StorageEncryption/AtRestEncryptionAlgorithm/metric.rego
+++ b/metrics/StorageEncryption/AtRestEncryptionAlgorithm/metric.rego
@@ -8,10 +8,10 @@ default applicable = false
 
 default compliant = false
 
-applicable {
+applicable if {
 	enc
 }
 
-compliant {
+compliant if {
 	compare(data.operator, data.target_value, enc[_].algorithm)
 }

--- a/metrics/StorageEncryption/AtRestEncryptionEnabled/metric.rego
+++ b/metrics/StorageEncryption/AtRestEncryptionEnabled/metric.rego
@@ -8,10 +8,10 @@ default applicable = false
 
 default compliant = false
 
-applicable {
+applicable if {
 	enc
 }
 
-compliant {
+compliant if {
 	compare(data.operator, data.target_value, enc[_].enabled)
 }


### PR DESCRIPTION
After updating **github.com/open-policy-agent/opa** from version **0.69.0 to 1.1.0** in Clouditor, we now need to use the if keyword before the rules. Currently, there is a pull request in the Clouditor repository addressing this change, which will be merged soon.

Instead of 
```
applicable {}
compliant {}
```
we must use 
```
applicable if {}
compliant if {}
```